### PR TITLE
Revert "Vo0do o line 115 mapping values are not allowed in this context"

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -112,6 +112,8 @@ objects:
             timeoutSeconds: 30
             failureThreshold: 3
             successThreshold: 1
+            tcpSocket:
+              port: ${{API_BACKBONE_SERVICE_PORT}}
           readinessProbe:
             tcpSocket:
               port: ${{API_BACKBONE_SERVICE_PORT}}


### PR DESCRIPTION
not this error if clone repo in local mashine